### PR TITLE
Make crate license Apache 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "feistel-permutation-rs"
 version = "0.1.0"
 edition = "2021"
 description = "Constant time, constant space permutations with Feistel Network ciphers."
-license = "GPL-3.0-or-later"
+license = "Apache-2.0"
 repository = "https://github.com/drtconway/permutation-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
I missed this previously, but noticed the GPL 3.0 license on crates.io.