### PR TITLE
Swap variables using destructuring assignment

### DIFF
--- a/src/feistel.rs
+++ b/src/feistel.rs
@@ -36,9 +36,7 @@ where
         let (mut l, mut r) = self.split(x);
         for k in self.keys.iter() {
             l ^= self.hash(*k, r);
-            let t = l;
-            l = r;
-            r = t;
+            (l, r) = (r, l);
         }
         self.combine(r, l)
     }

--- a/src/feistel.rs
+++ b/src/feistel.rs
@@ -46,9 +46,7 @@ where
         let (mut l, mut r) = self.split(x);
         for k in self.keys.iter().rev() {
             l ^= self.hash(*k, r);
-            let t = l;
-            l = r;
-            r = t;
+            (l, r) = (r, l);
         }
         self.combine(r, l)
     }


### PR DESCRIPTION
This construct was stabilised in Rust 1.59.

See https://stackoverflow.com/questions/31798737/how-to-swap-two-variables.

Since Rust 1.59 was released in February 2022, before this repository existed, you may care to apply this change. If you would prefer to support earlier versions of Rust, don't hesitate to close this PR.