### PR TITLE
Add owned iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feistel-permutation-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Constant time, constant space permutations with Feistel Network ciphers."
 license = "Apache-2.0"

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -60,7 +60,7 @@ where
         PermutationIterator::new(self, begin, end)
     }
 
-    /// Construct an iterator over the subset `begin..end` of the permutation.
+    /// Transform the Permutation into an iterator over the subset `begin..end` of the permutation.
     pub fn into_range(self, begin: u64, end: u64) -> OwnedPermutationIterator<B> {
         assert!(begin <= end);
         assert!(end <= self.n);
@@ -73,7 +73,7 @@ impl<B: std::hash::BuildHasher> IntoIterator for Permutation<B> {
 
     type IntoIter = OwnedPermutationIterator<B>;
 
-    /// Transform the entire Permutation into an iterator.
+    /// Transform the Permutation into an iterator.
     fn into_iter(self) -> Self::IntoIter {
         let end = self.n;
         OwnedPermutationIterator::new(self, 0, end)

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::hash::BuildHasher;
 
-use crate::{Feistel, DefaultBuildHasher};
+use crate::{DefaultBuildHasher, Feistel};
 
 /// An object of constructing random access permutations.
 pub struct Permutation<B = DefaultBuildHasher>
@@ -59,6 +59,25 @@ where
         assert!(end <= self.n);
         PermutationIterator::new(self, begin, end)
     }
+
+    /// Construct an iterator over the subset `begin..end` of the permutation.
+    pub fn into_range(self, begin: u64, end: u64) -> OwnedPermutationIterator<B> {
+        assert!(begin <= end);
+        assert!(end <= self.n);
+        OwnedPermutationIterator::new(self, begin, end)
+    }
+}
+
+impl<B: std::hash::BuildHasher> IntoIterator for Permutation<B> {
+    type Item = u64;
+
+    type IntoIter = OwnedPermutationIterator<B>;
+
+    /// Transform the entire Permutation into an iterator.
+    fn into_iter(self) -> Self::IntoIter {
+        let end = self.n;
+        OwnedPermutationIterator::new(self, 0, end)
+    }
 }
 
 /// An iterator over a [`Permutation`] object.
@@ -101,6 +120,46 @@ where
     }
 }
 
+/// An iterator over a [`Permutation`] object that owns the Permutation.
+pub struct OwnedPermutationIterator<B>
+where
+    B: BuildHasher,
+{
+    source: Permutation<B>,
+    curr: u64,
+    end: u64,
+}
+
+impl<B> OwnedPermutationIterator<B>
+where
+    B: BuildHasher,
+{
+    fn new(source: Permutation<B>, begin: u64, end: u64) -> OwnedPermutationIterator<B> {
+        OwnedPermutationIterator {
+            source,
+            curr: begin,
+            end,
+        }
+    }
+}
+
+impl<B> Iterator for OwnedPermutationIterator<B>
+where
+    B: BuildHasher,
+{
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.curr == self.end {
+            None
+        } else {
+            let res = self.source.get(self.curr);
+            self.curr += 1;
+            Some(res)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use xxhash_rust::xxh64;
@@ -108,7 +167,7 @@ mod tests {
     use super::*;
 
     fn triangular_variance(a: f64, b: f64, c: f64) -> f64 {
-        (a*a + b*b + c*c - a*b - a*c - b*c) / 18.0
+        (a * a + b * b + c * c - a * b - a * c - b * c) / 18.0
     }
 
     fn triangular_sd(a: f64, b: f64, c: f64) -> f64 {
@@ -134,11 +193,11 @@ mod tests {
         for i in 0..n as usize {
             let d = (xs[i] as f64) - (i as f64);
             sx += d;
-            sx2 += d*d;
+            sx2 += d * d;
         }
         let m_bar = sx / nf;
         assert_eq!(m_bar, 0.0);
-        let v_bar = sx2 / nf - m_bar*m_bar;
+        let v_bar = sx2 / nf - m_bar * m_bar;
         let sd_bar = v_bar.sqrt();
         let sd = triangular_sd(-nf, nf, 0.0);
         let std_error = sd / nf.sqrt();


### PR DESCRIPTION
Hey i like you crate, 
i just needed for my use case a way to have an Iterator that consumes Permutation. 

Because I want to be able to do things like this: 
```rust 
    pub fn get_random_sampled_and_mapped_iterator(self, n: u64) -> impl IntoIterator<Item = <The map result>> {
        let seed = 29;
        let perm = Permutation::new(n seed, DefaultBuildHasher::new());
        perm.into_iter().map(|i| <some map function>)
    }
```

If you like you can merge it. 
:)
